### PR TITLE
Disable eclipse checks for JavaDoc and missing @NonNullByDefault

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -50,6 +50,8 @@
 
 		<cpd.excludeFromFailureFile>${project.basedir}/cpd-excludes.csv</cpd.excludeFromFailureFile>
 		<compilerArgument>-parameters</compilerArgument>
+		<org.eclipse.jdt.core.compiler.annotation.missingNonNullByDefaultAnnotation>ignore</org.eclipse.jdt.core.compiler.annotation.missingNonNullByDefaultAnnotation>
+		<org.eclipse.jdt.core.compiler.doc.comment.support>disabled</org.eclipse.jdt.core.compiler.doc.comment.support>
 
 		<guice.version>4.2.1</guice.version>
 		<undertow.version>2.0.5.Final</undertow.version>


### PR DESCRIPTION
As oversigt code is not fully documented until now, Eclipse should not warn on missing JavaDoc for now.

In addition NonNullByDefault behaviour is not what was intended at the oversigt beginning. As such Eclipse warning about missing @NonNullByDefault annotations should be hidden, too.