### PR TITLE
Update dependencies

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -73,7 +73,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.25</version>
+			<version>1.7.26</version>
 		</dependency>
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
@@ -85,7 +85,7 @@
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.25.2</version>
+			<version>3.28.0</version>
 		</dependency>
 
 		<!-- startup properties made easy -->
@@ -132,12 +132,12 @@
 		<dependency>
 			<groupId>org.hibernate.validator</groupId>
 			<artifactId>hibernate-validator</artifactId>
-			<version>6.0.13.Final</version>
+			<version>6.0.17.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>org.hibernate.validator</groupId>
 			<artifactId>hibernate-validator-annotation-processor</artifactId>
-			<version>6.0.13.Final</version>
+			<version>6.0.17.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.web</groupId>
@@ -149,7 +149,7 @@
 		<dependency>
 			<groupId>org.jboss.spec.javax.ws.rs</groupId>
 			<artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
-			<version>1.0.1.Final</version>
+			<version>1.0.3.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>
@@ -228,29 +228,29 @@
 		<dependency>
 			<groupId>io.swagger</groupId>
 			<artifactId>swagger-core</artifactId>
-			<version>1.5.21</version>
+			<version>1.5.22</version>
 		</dependency>
 		<dependency>
 			<groupId>io.swagger</groupId>
 			<artifactId>swagger-models</artifactId>
-			<version>1.5.21</version>
+			<version>1.5.22</version>
 		</dependency>
 		<dependency>
 			<groupId>io.swagger</groupId>
 			<artifactId>swagger-annotations</artifactId>
-			<version>1.5.21</version>
+			<version>1.5.22</version>
 		</dependency>
 		<dependency>
 			<groupId>io.swagger</groupId>
 			<artifactId>swagger-jaxrs</artifactId>
-			<version>1.5.21</version>
+			<version>1.5.22</version>
 		</dependency>
 
 		<!-- String similarity -->
 		<dependency>
 			<groupId>info.debatty</groupId>
 			<artifactId>java-string-similarity</artifactId>
-			<version>1.1.0</version>
+			<version>1.2.1</version>
 		</dependency>
 
 		<!-- Microsoft API for Exchange access -->
@@ -291,7 +291,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
-			<version>3.4</version>
+			<version>3.9</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>
@@ -300,7 +300,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-beans</artifactId>
-			<version>5.1.1.RELEASE</version>
+			<version>5.1.8.RELEASE</version>
 		</dependency>
 
 		<!-- JSON -->
@@ -357,21 +357,21 @@
 		<dependency>
 			<groupId>org.codehaus.jettison</groupId>
 			<artifactId>jettison</artifactId>
-			<version>1.1</version>
+			<version>1.4.0</version>
 		</dependency>
 
 		<!-- SSH support -->
 		<dependency>
 			<groupId>com.jcraft</groupId>
 			<artifactId>jsch</artifactId>
-			<version>0.1.54</version>
+			<version>0.1.55</version>
 		</dependency>
 
 		<!-- Calendar with holidays -->
 		<dependency>
 			<groupId>de.jollyday</groupId>
 			<artifactId>jollyday</artifactId>
-			<version>0.5.6</version>
+			<version>0.5.8</version>
 		</dependency>
 
 		<!-- Mail sending -->
@@ -385,7 +385,7 @@
 		<dependency>
 			<groupId>org.eclipse.jgit</groupId>
 			<artifactId>org.eclipse.jgit</artifactId>
-			<version>5.1.2.201810061102-r</version>
+			<version>5.4.0.201906121030-r</version>
 		</dependency>
 
 		<!-- Testing -->
@@ -398,7 +398,7 @@
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
-			<version>3.11.1</version>
+			<version>3.12.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -409,7 +409,7 @@
 		<dependency>
 			<groupId>org.jboss.xnio</groupId>
 			<artifactId>xnio-api</artifactId>
-			<version>3.3.8.Final</version>
+			<version>3.7.2.Final</version>
 		</dependency>
 	</dependencies>
 

--- a/jira-rest-java-client-fix/pom.xml
+++ b/jira-rest-java-client-fix/pom.xml
@@ -63,7 +63,7 @@
 		<dependency>
 			<groupId>com.google.inject</groupId>
 			<artifactId>guice</artifactId>
-			<version>4.2.1</version>
+			<version>4.2.2</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
We should keep our dependencies up-to-date in order to minimize effort on finding compatibility problems when updating later.

These changes have not been tested, yet!