### PR TITLE
Fix duplicate dependency by removing of one of the duplicates

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -113,11 +113,6 @@
 			<version>1.0.0.Final</version>
 		</dependency>
 		<dependency>
-			<groupId>org.jboss.spec.javax.servlet</groupId>
-			<artifactId>jboss-servlet-api_4.0_spec</artifactId>
-			<version>1.0.0.Final</version>
-		</dependency>
-		<dependency>
 			<groupId>io.undertow</groupId>
 			<artifactId>undertow-servlet</artifactId>
 			<version>${undertow.version}</version>


### PR DESCRIPTION
This fixes an invalidity of the POM, which is warned by Maven on every run.