### PR TITLE
Update dependencies (+ small things)

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -186,7 +186,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.9.9</version>
+			<version>2.9.9.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -51,14 +51,6 @@
 		<cpd.excludeFromFailureFile>${project.basedir}/cpd-excludes.csv</cpd.excludeFromFailureFile>
 		<spotbugs.excludeFilterFile>${project.basedir}/spotbugs-excludes.xml</spotbugs.excludeFilterFile>
 		<org.eclipse.jdt.core.compiler.doc.comment.support>disabled</org.eclipse.jdt.core.compiler.doc.comment.support>
-
-		<freemarker.version>2.3.28</freemarker.version>
-		<guice.version>4.2.2</guice.version>
-		<jackson.version>2.9.9.1</jackson.version>
-		<resteasy.version>3.8.1.Final</resteasy.version>
-		<undertow.version>2.0.22.Final</undertow.version>
-		<weld.version>2.4.8.Final</weld.version>
-		<wro.version>1.8.0</wro.version>
 	</properties>
 
 	<dependencies>
@@ -99,7 +91,7 @@
 		<dependency>
 			<groupId>io.undertow</groupId>
 			<artifactId>undertow-core</artifactId>
-			<version>${undertow.version}</version>
+			<version>2.0.22.Final</version>
 		</dependency>
 		<!-- undertow-servlet for WRO -->
 		<dependency>
@@ -115,7 +107,7 @@
 		<dependency>
 			<groupId>io.undertow</groupId>
 			<artifactId>undertow-servlet</artifactId>
-			<version>${undertow.version}</version>
+			<version>2.0.22.Final</version>
 		</dependency>
 
 		<!-- Validation -->
@@ -149,62 +141,62 @@
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>
 			<artifactId>resteasy-jaxrs</artifactId>
-			<version>${resteasy.version}</version>
+			<version>3.8.1.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>
 			<artifactId>resteasy-client</artifactId>
-			<version>${resteasy.version}</version>
+			<version>3.8.1.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>
 			<artifactId>resteasy-cdi</artifactId>
-			<version>${resteasy.version}</version>
+			<version>3.8.1.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>
 			<artifactId>resteasy-links</artifactId>
-			<version>${resteasy.version}</version>
+			<version>3.8.1.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>
 			<artifactId>resteasy-guice</artifactId>
-			<version>${resteasy.version}</version>
+			<version>3.8.1.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>
 			<artifactId>resteasy-jackson2-provider</artifactId>
-			<version>${resteasy.version}</version>
+			<version>3.8.1.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jboss.weld.servlet</groupId>
 			<artifactId>weld-servlet</artifactId>
-			<version>${weld.version}</version>
+			<version>2.4.8.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
-			<version>${jackson.version}</version>
+			<version>2.9.9</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<version>${jackson.version}</version>
+			<version>2.9.9</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>${jackson.version}</version>
+			<version>2.9.9</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>
 			<artifactId>jackson-datatype-jsr310</artifactId>
-			<version>${jackson.version}</version>
+			<version>2.9.9</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>
 			<artifactId>jackson-datatype-jdk8</artifactId>
-			<version>${jackson.version}</version>
+			<version>2.9.9</version>
 		</dependency>
 		<!--javax.el is dependency required by weld-servlet -->
 		<dependency>
@@ -259,7 +251,7 @@
 		<dependency>
 			<groupId>com.google.inject</groupId>
 			<artifactId>guice</artifactId>
-			<version>${guice.version}</version>
+			<version>4.2.2</version>
 		</dependency>
 
 		<!-- Aspect Oriented Programming (Intercepting API method calls for validation) -->
@@ -307,19 +299,19 @@
 		<dependency>
 			<groupId>org.freemarker</groupId>
 			<artifactId>freemarker</artifactId>
-			<version>${freemarker.version}</version>
+			<version>2.3.28</version>
 		</dependency>
 
 		<!-- CoffeScript & other script language stuff -->
 		<dependency>
 			<groupId>ro.isdc.wro4j</groupId>
 			<artifactId>wro4j-core</artifactId>
-			<version>${wro.version}</version>
+			<version>1.8.0</version>
 		</dependency>
 		<dependency>
 			<groupId>ro.isdc.wro4j</groupId>
 			<artifactId>wro4j-extensions</artifactId>
-			<version>${wro.version}</version>
+			<version>1.8.0</version>
 		</dependency>
 
 		<!-- JIRA support -->

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -54,8 +54,8 @@
 
 		<freemarker.version>2.3.28</freemarker.version>
 		<guice.version>4.2.2</guice.version>
-		<jackson.version>2.9.9</jackson.version>
-		<resteasy.version>3.8.0.Final</resteasy.version>
+		<jackson.version>2.9.9.1</jackson.version>
+		<resteasy.version>3.8.1.Final</resteasy.version>
 		<undertow.version>2.0.22.Final</undertow.version>
 		<weld.version>2.4.8.Final</weld.version>
 		<wro.version>1.8.0</wro.version>

--- a/core/src/main/java/com/hlag/oversigt/util/FileUtils.java
+++ b/core/src/main/java/com/hlag/oversigt/util/FileUtils.java
@@ -33,9 +33,9 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Splitter;
 import com.google.common.io.Resources;
-import com.hlag.oversigt.util.Utils.OperatingSystemType;
 
 import de.larssh.utils.SneakyException;
+import de.larssh.utils.SystemUtils;
 import de.larssh.utils.function.ThrowingConsumer;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -383,7 +383,7 @@ public final class FileUtils {
 	}
 
 	public static String toRegex(final String globPattern) {
-		if (Utils.getOperatingSystemType() == OperatingSystemType.Windows) {
+		if (SystemUtils.isWindows()) {
 			return toWindowsRegexPattern(globPattern);
 		}
 		return toUnixRegexPattern(globPattern);

--- a/core/src/main/java/com/hlag/oversigt/util/Utils.java
+++ b/core/src/main/java/com/hlag/oversigt/util/Utils.java
@@ -27,6 +27,7 @@ import java.util.stream.Stream.Builder;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeanUtils;
 
 import com.google.common.base.CaseFormat;
 import com.hlag.oversigt.security.Principal;

--- a/core/src/main/java/com/hlag/oversigt/util/Utils.java
+++ b/core/src/main/java/com/hlag/oversigt/util/Utils.java
@@ -10,7 +10,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -28,7 +27,6 @@ import java.util.stream.Stream.Builder;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.BeanUtils;
 
 import com.google.common.base.CaseFormat;
 import com.hlag.oversigt.security.Principal;
@@ -257,35 +255,6 @@ public final class Utils {
 			}
 		}
 		return result;
-	}
-
-	/**
-	 * types of Operating Systems
-	 */
-	public enum OperatingSystemType {
-		Windows,
-		MacOS,
-		Linux,
-		Other
-	}
-
-	/**
-	 * detect the operating system from the os.name System property and cache the
-	 * result
-	 *
-	 * @return the operating system detected
-	 */
-	public static OperatingSystemType getOperatingSystemType() {
-		final String osName = System.getProperty("os.name", "generic").toLowerCase(Locale.ENGLISH);
-		if (osName.indexOf("mac") >= 0 || osName.indexOf("darwin") >= 0) {
-			return OperatingSystemType.MacOS;
-		} else if (osName.indexOf("win") >= 0) {
-			return OperatingSystemType.Windows;
-		} else if (osName.indexOf("nux") >= 0) {
-			return OperatingSystemType.Linux;
-		} else {
-			return OperatingSystemType.Other;
-		}
 	}
 
 	public static <T> void copyProperties(final T source, final T target, final String... ignoreProperties) {

--- a/oversigt-ui/pom.xml
+++ b/oversigt-ui/pom.xml
@@ -46,6 +46,8 @@
 
 	<properties>
 		<mdep.analyze.skip>true</mdep.analyze.skip>
+
+		<exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
 	</properties>
 
 	<dependencies>
@@ -85,7 +87,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>exec-maven-plugin</artifactId>
-				<version>1.4.0</version>
+				<version>${exec-maven-plugin.version}</version>
 				<executions>
 					<execution>
 						<?m2e ignore?>

--- a/pom.xml
+++ b/pom.xml
@@ -59,23 +59,4 @@
 			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 		</repository>
 	</repositories>
-
-	<profiles>
-		<profile>
-			<activation>
-				<jdk>(9,)</jdk>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-javadoc-plugin</artifactId>
-						<configuration>
-							<additionalOptions>-html4</additionalOptions>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>de.lars-sh</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.9.3-SNAPSHOT</version>
+		<version>0.9.3</version>
 	</parent>
 
 	<groupId>com.hlag.oversigt</groupId>


### PR DESCRIPTION
- Updated dependencies
- Moved dependency versions from properties to the dependencies as (1) they are not used except for dependency versions and (2) multiple dependency versions should not be linked together to simplify automated updating.
- Remove Utils.getSystemOperatingType()
- Remove special JavaDoc handling for JDK 9 and above as that's handled by the parent POM now.