### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: java
-install: mvn install -DskipTests=true -Dgpg.skip=true --batch-mode --show-version
+jdk:
+  - openjdk8
+  - openjdk11
 
-env:
-  - NODE_VERSION="8.12.0"
+install: skip
+script: mvn install -Dgpg.skip=true --batch-mode --show-version --update-snapshots
 
-before_install:
-  - nvm install $NODE_VERSION
-  - npm install -g @angular/cli
+cache:
+  directories:
+    - $HOME/.m2

--- a/core/.travis.yml
+++ b/core/.travis.yml
@@ -1,2 +1,11 @@
 language: java
-install: mvn install -DskipTests=true -Dgpg.skip=true --batch-mode --show-version
+jdk:
+  - openjdk8
+  - openjdk11
+
+install: skip
+script: mvn install -Dgpg.skip=true --batch-mode --show-version --update-snapshots
+
+cache:
+  directories:
+    - $HOME/.m2

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -65,7 +65,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.26</version>
+			<version>1.7.28</version>
 		</dependency>
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
@@ -91,7 +91,7 @@
 		<dependency>
 			<groupId>io.undertow</groupId>
 			<artifactId>undertow-core</artifactId>
-			<version>2.0.23.Final</version>
+			<version>2.0.25.Final</version>
 		</dependency>
 		<!-- undertow-servlet for WRO -->
 		<dependency>
@@ -107,7 +107,7 @@
 		<dependency>
 			<groupId>io.undertow</groupId>
 			<artifactId>undertow-servlet</artifactId>
-			<version>2.0.23.Final</version>
+			<version>2.0.25.Final</version>
 		</dependency>
 
 		<!-- Validation -->
@@ -146,27 +146,27 @@
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>
 			<artifactId>resteasy-client</artifactId>
-			<version>3.8.1.Final</version>
+			<version>4.2.0.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>
 			<artifactId>resteasy-cdi</artifactId>
-			<version>3.8.1.Final</version>
+			<version>4.2.0.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>
 			<artifactId>resteasy-links</artifactId>
-			<version>3.8.1.Final</version>
+			<version>4.2.0.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>
 			<artifactId>resteasy-guice</artifactId>
-			<version>3.8.1.Final</version>
+			<version>4.2.0.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>
 			<artifactId>resteasy-jackson2-provider</artifactId>
-			<version>3.8.1.Final</version>
+			<version>4.2.0.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jboss.weld.servlet</groupId>
@@ -186,7 +186,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.9.9.2</version>
+			<version>2.9.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>
@@ -215,22 +215,22 @@
 		<dependency>
 			<groupId>io.swagger</groupId>
 			<artifactId>swagger-core</artifactId>
-			<version>1.5.22</version>
+			<version>1.5.23</version>
 		</dependency>
 		<dependency>
 			<groupId>io.swagger</groupId>
 			<artifactId>swagger-models</artifactId>
-			<version>1.5.22</version>
+			<version>1.5.23</version>
 		</dependency>
 		<dependency>
 			<groupId>io.swagger</groupId>
 			<artifactId>swagger-annotations</artifactId>
-			<version>1.5.22</version>
+			<version>1.5.23</version>
 		</dependency>
 		<dependency>
 			<groupId>io.swagger</groupId>
 			<artifactId>swagger-jaxrs</artifactId>
-			<version>1.5.22</version>
+			<version>1.5.23</version>
 		</dependency>
 
 		<!-- String similarity -->
@@ -265,7 +265,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>20.0</version>
+			<version>28.1-jre</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.findbugs</groupId>
@@ -285,7 +285,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-beans</artifactId>
-			<version>5.1.8.RELEASE</version>
+			<version>5.1.9.RELEASE</version>
 		</dependency>
 
 		<!-- JSON -->
@@ -299,7 +299,7 @@
 		<dependency>
 			<groupId>org.freemarker</groupId>
 			<artifactId>freemarker</artifactId>
-			<version>2.3.28</version>
+			<version>2.3.29</version>
 		</dependency>
 
 		<!-- CoffeScript & other script language stuff -->
@@ -323,7 +323,7 @@
 		<dependency>
 			<groupId>com.atlassian.jira</groupId>
 			<artifactId>jira-rest-java-client-api</artifactId>
-			<version>5.1.0</version>
+			<version>5.1.6</version>
 		</dependency>
 		<dependency>
 			<groupId>io.atlassian.util.concurrent</groupId>
@@ -361,14 +361,14 @@
 		<dependency>
 			<groupId>org.eclipse.jgit</groupId>
 			<artifactId>org.eclipse.jgit</artifactId>
-			<version>5.4.0.201906121030-r</version>
+			<version>5.4.2.201908231537-r</version>
 		</dependency>
 
 		<!-- Testing -->
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
-			<version>3.13.1</version>
+			<version>3.13.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -146,27 +146,27 @@
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>
 			<artifactId>resteasy-client</artifactId>
-			<version>4.2.0.Final</version>
+			<version>3.8.1.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>
 			<artifactId>resteasy-cdi</artifactId>
-			<version>4.2.0.Final</version>
+			<version>3.8.1.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>
 			<artifactId>resteasy-links</artifactId>
-			<version>4.2.0.Final</version>
+			<version>3.8.1.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>
 			<artifactId>resteasy-guice</artifactId>
-			<version>4.2.0.Final</version>
+			<version>3.8.1.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>
 			<artifactId>resteasy-jackson2-provider</artifactId>
-			<version>4.2.0.Final</version>
+			<version>3.8.1.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jboss.weld.servlet</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -262,10 +262,11 @@
 		</dependency>
 
 		<!-- other useful stuff -->
+		<!-- Must not be updated as long as the JIRA client requires a method that has been removed in version 21! -->
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>28.1-jre</version>
+			<version>20.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.findbugs</groupId>

--- a/jira-rest-java-client-fix/.travis.yml
+++ b/jira-rest-java-client-fix/.travis.yml
@@ -1,2 +1,11 @@
 language: java
-install: mvn install -DskipTests=true -Dgpg.skip=true --batch-mode --show-version
+jdk:
+  - openjdk8
+  - openjdk11
+
+install: skip
+script: mvn install -Dgpg.skip=true --batch-mode --show-version --update-snapshots
+
+cache:
+  directories:
+    - $HOME/.m2

--- a/jira-rest-java-client-fix/pom.xml
+++ b/jira-rest-java-client-fix/pom.xml
@@ -49,7 +49,7 @@
 		<dependency>
 			<groupId>com.atlassian.jira</groupId>
 			<artifactId>jira-rest-java-client-core</artifactId>
-			<version>5.1.0</version>
+			<version>5.1.6</version>
 		</dependency>
 
 		<!-- Missing inside the JIRA REST Client Implementation dependencies -->

--- a/jira-rest-java-client-fix/pom.xml
+++ b/jira-rest-java-client-fix/pom.xml
@@ -44,12 +44,16 @@
 		<url>https://travis-ci.org/Hapag-Lloyd/oversigt</url>
 	</ciManagement>
 
+	<properties>
+		<jira-rest-java-client-api.version>5.1.6</jira-rest-java-client-api.version>
+	</properties>
+
 	<dependencies>
 		<!-- JIRA REST Client Implementation -->
 		<dependency>
 			<groupId>com.atlassian.jira</groupId>
 			<artifactId>jira-rest-java-client-core</artifactId>
-			<version>5.1.6</version>
+			<version>${jira-rest-java-client-api.version}</version>
 		</dependency>
 
 		<!-- Missing inside the JIRA REST Client Implementation dependencies -->
@@ -79,9 +83,9 @@
 							<ignoredUsedUndeclaredDependencies>
 								<!-- Dependencies of the JIRA REST Client Implementation -->
 								<ignoredUsedUndeclaredDependency>com.atlassian.event:atlassian-event:jar:3.0.0</ignoredUsedUndeclaredDependency>
-								<ignoredUsedUndeclaredDependency>com.atlassian.httpclient:atlassian-httpclient-api:jar:2.0.0-m1</ignoredUsedUndeclaredDependency>
-								<ignoredUsedUndeclaredDependency>com.atlassian.httpclient:atlassian-httpclient-library:jar:2.0.0-m1</ignoredUsedUndeclaredDependency>
-								<ignoredUsedUndeclaredDependency>com.atlassian.jira:jira-rest-java-client-api:jar:5.1.0</ignoredUsedUndeclaredDependency>
+								<ignoredUsedUndeclaredDependency>com.atlassian.httpclient:atlassian-httpclient-api:jar:2.0.0</ignoredUsedUndeclaredDependency>
+								<ignoredUsedUndeclaredDependency>com.atlassian.httpclient:atlassian-httpclient-library:jar:2.0.0</ignoredUsedUndeclaredDependency>
+								<ignoredUsedUndeclaredDependency>com.atlassian.jira:jira-rest-java-client-api:jar:${jira-rest-java-client-api.version}</ignoredUsedUndeclaredDependency>
 								<ignoredUsedUndeclaredDependency>com.atlassian.sal:sal-api:jar:3.0.7</ignoredUsedUndeclaredDependency>
 								<ignoredUsedUndeclaredDependency>com.google.code.findbugs:jsr305:jar:3.0.2</ignoredUsedUndeclaredDependency>
 								<ignoredUsedUndeclaredDependency>org.slf4j:slf4j-api:jar:1.7.10</ignoredUsedUndeclaredDependency>

--- a/oversigt-ui/.travis.yml
+++ b/oversigt-ui/.travis.yml
@@ -1,2 +1,11 @@
 language: java
-install: mvn install -DskipTests=true -Dgpg.skip=true --batch-mode --show-version
+jdk:
+  - openjdk8
+  - openjdk11
+
+install: skip
+script: mvn install -Dgpg.skip=true --batch-mode --show-version --update-snapshots
+
+cache:
+  directories:
+    - $HOME/.m2

--- a/oversigt-ui/pom.xml
+++ b/oversigt-ui/pom.xml
@@ -54,7 +54,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>28.0-jre</version>
+			<version>28.1-jre</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,8 @@
 	<parent>
 		<groupId>de.lars-sh</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.9.3</version>
+		<version>0.9.4</version>
+		<relativePath></relativePath>
 	</parent>
 
 	<groupId>com.hlag.oversigt</groupId>


### PR DESCRIPTION
- Minor dependency updates
- Update parent to the latest release version
- Update .travis.yml to compile with both, OpenJDK 8 and 11