### PR TITLE
Add XPath processing

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -294,6 +294,11 @@
 			<artifactId>json-path</artifactId>
 			<version>2.4.0</version>
 		</dependency>
+		<dependency>
+			<groupId>de.lars-sh</groupId>
+			<artifactId>json-dom</artifactId>
+			<version>0.9.1</version>
+		</dependency>
 
 		<!-- templates -->
 		<dependency>

--- a/core/src/main/java/com/hlag/oversigt/sources/InternetTextExtractionEventSource.java
+++ b/core/src/main/java/com/hlag/oversigt/sources/InternetTextExtractionEventSource.java
@@ -29,7 +29,7 @@ import com.hlag.oversigt.util.text.TextProcessor;
 		view = "List",
 		hiddenDataItems = "updated-at-message")
 public class InternetTextExtractionEventSource extends AbstractDownloadEventSource<TwoColumnListEvent<String>> {
-	private ValueExtraction[] valueExtractions = new ValueExtraction[] { new ValueExtraction("", "$[*].name") };
+	private ValueExtraction[] valueExtractions = new ValueExtraction[] { new ValueExtraction("true", "$[*].name") };
 
 	private Summarization summarization = Summarization.ConcatenationWithLineBreak;
 
@@ -84,7 +84,8 @@ public class InternetTextExtractionEventSource extends AbstractDownloadEventSour
 		return Objects.toString(value);
 	}
 
-	@Property(name = "Default Value", description = "The default value to show if the JSONPath does not match")
+	@Property(name = "Default Value",
+			description = "The default value to show if no or an empty value has been extracted")
 	public String getDefaultValue() {
 		return defaultValue;
 	}
@@ -115,6 +116,7 @@ public class InternetTextExtractionEventSource extends AbstractDownloadEventSour
 		final String result = new TextProcessor().registerDatetimeFunctions()
 				.registerJsonPathFunction(downloadedContent)
 				.registerRegularExpressionFunction(downloadedContent)
+				.registerXPathFunction(downloadedContent)
 				.process(valueExtraction.condition)
 				.trim();
 		try {
@@ -138,6 +140,7 @@ public class InternetTextExtractionEventSource extends AbstractDownloadEventSour
 		return new TextProcessor().registerDatetimeFunctions()
 				.registerJsonPathFunction(downloadedContent)
 				.registerRegularExpressionFunction(downloadedContent)
+				.registerXPathFunction(downloadedContent)
 				.process(valueExtraction.format);
 	}
 

--- a/core/src/main/java/com/hlag/oversigt/util/text/JsonPathFunction.java
+++ b/core/src/main/java/com/hlag/oversigt/util/text/JsonPathFunction.java
@@ -5,23 +5,31 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import com.hlag.oversigt.util.JsonUtils;
+import com.jayway.jsonpath.InvalidJsonException;
 import com.jayway.jsonpath.JsonPath;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 class JsonPathFunction implements Function<String, String> {
 
-	private final String json;
+	private final String probablyJson;
 
-	JsonPathFunction(final String json) {
-		this.json = json;
+	JsonPathFunction(final String probablyJson) {
+		this.probablyJson = probablyJson;
 	}
 
+	@Nullable
 	@Override
 	public String apply(@Nullable final String jsonPathString) {
 		Objects.requireNonNull(jsonPathString, "Input for a JsonPath must be non null");
 		final JsonPath jsonPath = JsonPath.compile(jsonPathString);
-		final Object result = JsonUtils.extractValueUsingJsonPath(jsonPath, json);
+
+		final Object result;
+		try {
+			result = JsonUtils.extractValueUsingJsonPath(jsonPath, probablyJson);
+		} catch (@SuppressWarnings("unused") final InvalidJsonException e) {
+			return null;
+		}
 
 		if (result == null) {
 			return "";

--- a/core/src/main/java/com/hlag/oversigt/util/text/TextProcessor.java
+++ b/core/src/main/java/com/hlag/oversigt/util/text/TextProcessor.java
@@ -3,9 +3,12 @@ package com.hlag.oversigt.util.text;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.w3c.dom.Document;
 
 public final class TextProcessor {
 	private static final Pattern PATTERN_DATA_REPLACEMENT
@@ -30,12 +33,20 @@ public final class TextProcessor {
 		return this;
 	}
 
-	public TextProcessor registerJsonPathFunction(final String json) {
-		return registerFunction("jsonpath", jsonpath -> new JsonPathFunction(json).apply(jsonpath));
+	public TextProcessor registerJsonPathFunction(final String probablyJson) {
+		return registerFunction("jsonpath", new JsonPathFunction(probablyJson)::apply);
 	}
 
 	public TextProcessor registerRegularExpressionFunction(final String value) {
-		return registerFunction("regex", regex -> new RegularExpressionFunction(value).apply(regex));
+		return registerFunction("regex", new RegularExpressionFunction(value)::apply);
+	}
+
+	public TextProcessor registerXPathFunction(final Optional<Document> document) {
+		return registerFunction("xpath", new XPathFunction(document)::apply);
+	}
+
+	public TextProcessor registerXPathFunction(final String probablyJsonOrXml) {
+		return registerFunction("xpath", new XPathFunction(probablyJsonOrXml)::apply);
 	}
 
 	public String process(final String value) {

--- a/core/src/main/java/com/hlag/oversigt/util/text/TextProcessor.java
+++ b/core/src/main/java/com/hlag/oversigt/util/text/TextProcessor.java
@@ -10,6 +10,8 @@ import java.util.regex.Pattern;
 
 import org.w3c.dom.Document;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
+
 public final class TextProcessor {
 	private static final Pattern PATTERN_DATA_REPLACEMENT
 			= Pattern.compile("\\$\\{(?<processor>[a-z]+)(:(?<input>[^\\}]+))?\\}");
@@ -58,8 +60,16 @@ public final class TextProcessor {
 				throw new RuntimeException("Data replacement '" + mainMatcher.group(1) + "' is unknown.");
 			}
 
-			string = string.replace(mainMatcher.group(),
-					processors.get(processorName).apply(mainMatcher.group("input")));
+			@Nullable
+			final String input = mainMatcher.group("input");
+			if (input != null) {
+				final Function<String, String> processor = processors.get(processorName);
+				@Nullable
+				final String replacement = processor.apply(input);
+				if (replacement != null) {
+					string = string.replace(mainMatcher.group(), replacement);
+				}
+			}
 		}
 		return string;
 	}

--- a/core/src/main/java/com/hlag/oversigt/util/text/XPathFunction.java
+++ b/core/src/main/java/com/hlag/oversigt/util/text/XPathFunction.java
@@ -1,0 +1,82 @@
+package com.hlag.oversigt.util.text;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import de.larssh.json.dom.JsonDomDocument;
+import de.larssh.json.dom.values.JacksonDomValue;
+import de.larssh.utils.dom.XPathExpressions;
+import de.larssh.utils.function.ThrowingFunction;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+class XPathFunction implements ThrowingFunction<String, String> {
+	private static Optional<JsonDomDocument<JsonNode>> createJsonDocument(final String probablyJson) {
+		JsonNode jsonNode;
+		try {
+			jsonNode = new ObjectMapper().readTree(probablyJson);
+		} catch (@SuppressWarnings("unused") final IOException e) {
+			return Optional.empty();
+		}
+		return Optional.of(new JsonDomDocument<>(new JacksonDomValue(jsonNode)));
+	}
+
+	private static Optional<Document> createXmlDocument(final String probablyXml) {
+		try {
+			return Optional.of(DocumentBuilderFactory.newInstance()
+					.newDocumentBuilder()
+					.parse(new InputSource(new StringReader(probablyXml))));
+		} catch (@SuppressWarnings("unused") SAXException | IOException | ParserConfigurationException e) {
+			return Optional.empty();
+		}
+	}
+
+	private Optional<? extends Document> document = Optional.empty();
+
+	private boolean documentHasBeenExtracted = false;
+
+	private final String probablyJsonOrXml;
+
+	XPathFunction(final String probablyJsonOrXml) {
+		this.probablyJsonOrXml = probablyJsonOrXml;
+	}
+
+	XPathFunction(final Optional<Document> document) {
+		this.document = document;
+		documentHasBeenExtracted = true;
+		probablyJsonOrXml = "";
+	}
+
+	@Nullable
+	@Override
+	public String applyThrowing(@Nullable final String xPathString) throws XPathExpressionException {
+		Objects.requireNonNull(xPathString, "Input for a XPath must be non null");
+
+		if (!documentHasBeenExtracted) {
+			document = createJsonDocument(probablyJsonOrXml);
+			if (!document.isPresent()) {
+				document = createXmlDocument(probablyJsonOrXml);
+			}
+			documentHasBeenExtracted = true;
+		}
+
+		if (!document.isPresent()) {
+			return null;
+		}
+
+		return XPathExpressions.getString(document.get(), XPathFactory.newInstance().newXPath().compile(xPathString));
+	}
+}


### PR DESCRIPTION
Add XPath processing for XML and JSON documents to InternetTexttExtractionEventSource

Note: JavaDoc error. This issue requires #68 to be merged before.