### PR TITLE
Increase build performance

### DIFF
--- a/.github/workflows/push-and-pull_request.yml
+++ b/.github/workflows/push-and-pull_request.yml
@@ -52,7 +52,7 @@ jobs:
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.java-version == 8 && steps.version.outputs.is-snapshot == 'true' }}
         run: |
           set -o errexit -o pipefail
-          mvn deploy site --batch-mode --show-version 2>&1 | tee --append mvnout.txt
+          mvn deploy site --define maven.wagon.rto=60000 --batch-mode --show-version 2>&1 | tee --append mvnout.txt
           set +o errexit +o pipefail
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -61,7 +61,7 @@ jobs:
         if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' || matrix.java-version != 8 || steps.version.outputs.is-snapshot != 'true' }}
         run: |
           set -o errexit -o pipefail
-          mvn verify site --define gpg.skip=true --batch-mode --show-version 2>&1 | tee --append mvnout.txt
+          mvn verify site --define gpg.skip=true --define maven.wagon.rto=60000 --batch-mode --show-version 2>&1 | tee --append mvnout.txt
           set +o errexit +o pipefail
       - name: Check Output
         shell: bash {0}

--- a/pom.xml
+++ b/pom.xml
@@ -109,5 +109,6 @@
 					</reportSet>
 				</reportSets>
 			</plugin>
+		</plugins>
 	</reporting>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,9 @@
 		<parent-pom.default-sources-folder>java</parent-pom.default-sources-folder>
 		<parent-pom.github.organization>Hapag-Lloyd</parent-pom.github.organization>
 		<parent-pom.github.project>oversigt</parent-pom.github.project>
+
+		<!-- Increased to use no-fork reports -->
+		<maven-jxr-plugin.version>3.1.1</maven-jxr-plugin.version>
 	</properties>
 
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -71,4 +71,43 @@
 			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 		</repository>
 	</repositories>
+
+	<reporting>
+		<plugins>
+			<!-- Sources -->
+			<plugin>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<reportSets>
+					<reportSet>
+						<reports>
+							<report>aggregate-no-fork</report>
+							<report>test-aggregate-no-fork</report>
+						</reports>
+					</reportSet>
+				</reportSets>
+			</plugin>
+			<plugin>
+				<artifactId>maven-jxr-plugin</artifactId>
+				<reportSets>
+					<reportSet>
+						<reports>
+							<report>jxr-no-fork</report>
+							<report>test-jxr-no-fork</report>
+						</reports>
+					</reportSet>
+				</reportSets>
+			</plugin>
+
+			<!-- Tests -->
+			<plugin>
+				<artifactId>maven-surefire-report-plugin</artifactId>
+				<reportSets>
+					<reportSet>
+						<reports>
+							<report>report-only</report>
+						</reports>
+					</reportSet>
+				</reportSets>
+			</plugin>
+	</reporting>
 </project>

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -49,9 +49,6 @@
 							<goal>npm</goal>
 						</goals>
 						<phase>compile</phase>
-						<configuration>
-							<arguments>install</arguments>
-						</configuration>
 					</execution>
 					<execution>
 						<id>npm-run-build-prod</id>
@@ -70,8 +67,6 @@
 				<artifactId>build-helper-maven-plugin</artifactId>
 				<executions>
 					<execution>
-						<id>add-resource</id>
-						<phase>generate-resources</phase>
 						<goals>
 							<goal>add-resource</goal>
 						</goals>

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -17,14 +17,6 @@
 		<mdep.analyze.skip>true</mdep.analyze.skip>
 	</properties>
 
-	<dependencies>
-		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>30.1.1-jre</version>
-		</dependency>
-	</dependencies>
-
 	<build>
 		<plugins>
 			<plugin>

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -15,9 +15,6 @@
 	<properties>
 		<parent-pom.create-readme-md>false</parent-pom.create-readme-md>
 		<mdep.analyze.skip>true</mdep.analyze.skip>
-
-		<!-- Versions: Plugins -->
-		<exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
 	</properties>
 
 	<dependencies>
@@ -51,6 +48,7 @@
 						<goals>
 							<goal>npm</goal>
 						</goals>
+						<phase>compile</phase>
 						<configuration>
 							<arguments>install</arguments>
 						</configuration>
@@ -60,6 +58,7 @@
 						<goals>
 							<goal>npm</goal>
 						</goals>
+						<phase>compile</phase>
 						<configuration>
 							<arguments>run buildProd</arguments>
 						</configuration>

--- a/ui/src/main/java/com/hlag/oversigt/web/ui/OversigtUiHelper.java
+++ b/ui/src/main/java/com/hlag/oversigt/web/ui/OversigtUiHelper.java
@@ -1,10 +1,12 @@
 package com.hlag.oversigt.web.ui;
 
 import java.net.URI;
-import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Optional;
 
-import com.google.common.io.Resources;
+import de.larssh.utils.Nullables;
+import de.larssh.utils.io.Resources;
 
 /**
  * Class containing information to get to the Oversigt UI.
@@ -24,10 +26,9 @@ public final class OversigtUiHelper {
 	 * @return the URI to the Oversigt UI if found - otherwise empty()
 	 */
 	public static Optional<URI> getPathToUiResources() {
-		try {
-			return Optional.of(Resources.getResource("oversigt-ui").toURI());
-		} catch (@SuppressWarnings("unused") final IllegalArgumentException | URISyntaxException ignore) {
-			return Optional.empty();
-		}
+		final ClassLoader classLoader = Nullables.orElseGet( //
+				OversigtUiHelper.class.getClassLoader(),
+				ClassLoader::getSystemClassLoader);
+		return Resources.getResource(classLoader, Paths.get("oversigt-ui")).map(Path::toUri);
 	}
 }

--- a/ui/src/main/java/com/hlag/oversigt/web/ui/OversigtUiHelper.java
+++ b/ui/src/main/java/com/hlag/oversigt/web/ui/OversigtUiHelper.java
@@ -26,9 +26,8 @@ public final class OversigtUiHelper {
 	 * @return the URI to the Oversigt UI if found - otherwise empty()
 	 */
 	public static Optional<URI> getPathToUiResources() {
-		final ClassLoader classLoader = Nullables.orElseGet( //
-				OversigtUiHelper.class.getClassLoader(),
-				ClassLoader::getSystemClassLoader);
+		final ClassLoader classLoader
+				= Nullables.orElseGet(OversigtUiHelper.class.getClassLoader(), ClassLoader::getSystemClassLoader);
 		return Resources.getResource(classLoader, Paths.get("oversigt-ui")).map(Path::toUri);
 	}
 }

--- a/ui/src/main/java/com/hlag/oversigt/web/ui/OversigtUiHelper.java
+++ b/ui/src/main/java/com/hlag/oversigt/web/ui/OversigtUiHelper.java
@@ -26,8 +26,8 @@ public final class OversigtUiHelper {
 	 * @return the URI to the Oversigt UI if found - otherwise empty()
 	 */
 	public static Optional<URI> getPathToUiResources() {
-		final ClassLoader classLoader
-				= Nullables.orElseGet(OversigtUiHelper.class.getClassLoader(), ClassLoader::getSystemClassLoader);
+		final ClassLoader classLoader = Nullables.orElseGet(Thread.currentThread().getContextClassLoader(),
+				ClassLoader::getSystemClassLoader);
 		return Resources.getResource(classLoader, Paths.get("oversigt-ui")).map(Path::toUri);
 	}
 }


### PR DESCRIPTION
I tried to increase the build performance.

1. From what I've seen, the first few Maven lifecycle phases were executed multiple times, caused by the Maven reports, that _fork_ the Maven lifecycle.
Therefore I changed them from the forking report to the non-forking where possible. That should make about 2-3 minutes of the buildjob execution.
2. In addition I noticed, that NPM is executed during the `generate-resources` phase and takes about half a minute. By moving the NPM execution to the `compile` phase, it's executed less often, as most Maven reports just fork the first few lifecycle phases. This should make about 1-2 minutes of the buildjob execution time.
3. During the `analyze-report` of the `maven-dependency-plugin` some long timeout were raised or similar when building the report for the UI project. It seemed as if the dependency to Guava was a problem. Therefore I just removed that dependency and simplified the coding. Sadly that did not help.
4. The `maven-dependency-plugin` creates a delay of 15 minutes, still...

UPDATE: It seems performing some call to one of the repository times out for whatever reason. I just reduced teh default timeout to one minute.